### PR TITLE
feat: Remove default export

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,4 +4,3 @@ export * from '@seamapi/http/connect'
 export * from '@seamapi/types/connect'
 export * from '@seamapi/webhook'
 export { Seam }
-export { Seam as default }


### PR DESCRIPTION
Mixing named and default exports issues a build warning for commonjs because it can create hard to debug issues with different bundlers and JS environments.

Consumers using

```js
import Seam from 'seam'
```

Should instead use

```js
import { Seam } from 'seam'
```